### PR TITLE
Removed the deprecated 'version' attribute to avoid warnings

### DIFF
--- a/docker-compose-community.yml
+++ b/docker-compose-community.yml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 services:
   schema:
     image: confluentinc/cp-schema-registry:7.8.0


### PR DESCRIPTION
## Summary
This PR is to address the docker warning of the '`version`' attribute being obsolete.

### Change made to code
The `docker/compose/docker-compose.mysql.yml` files version line has been removed to avoid the warning popping up.